### PR TITLE
chore(ci): remove deprecated delete-tag-and-release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dev-drprasad/delete-tag-and-release@v1.1
-        with:
-          delete_release: true
-          tag_name: latest
+      - name: Delete existing "latest" release and tag
+        run: |
+          set -euo pipefail
+          gh release delete latest --cleanup-tag --yes || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Replace dev-drprasad/delete-tag-and-release (unmaintained, archived) with a direct gh CLI call, as recommended by the maintainer.

https://github.com/dev-drprasad/delete-tag-and-release/commit/6c843f0f78b0666910a98f4f445d09e3a3b32719